### PR TITLE
update example js to use lists

### DIFF
--- a/extensions/custom-footer/src/Extension.js
+++ b/extensions/custom-footer/src/Extension.js
@@ -3,6 +3,7 @@ import {
   InlineLayout,
   InlineStack,
   Link,
+  ListItem,
   Text,
 } from '@shopify/ui-extensions/checkout';
 
@@ -14,19 +15,54 @@ export default function renderExtension({root, shop}) {
   const leftColumn = root.createComponent(
     InlineStack,
     {
-      spacing: 'extraTight',
-      blockAlignment: 'center',
+      spacing: "extraTight",
+      blockAlignment: "center",
+      accessibilityRole: "orderedList",
     },
     [
-      root.createComponent(Link, {to: storefrontUrl}, 'Home'),
-      root.createComponent(Icon, {source: 'chevronRight', size: 'extraSmall'}),
       root.createComponent(
-        Link,
-        {to: new URL('/collections', storefrontUrl).href},
-        'Shop',
+        InlineStack,
+        {
+          spacing: "extraTight",
+          blockAlignment: "center",
+          accessibilityRole: "listItem",
+        },
+        [
+          root.createComponent(Link, {to: storefrontUrl}, "Home"),
+          root.createComponent(Icon, {
+            source: "chevronRight",
+            size: "extraSmall",
+          }),
+        ],
       ),
-      root.createComponent(Icon, {source: 'chevronRight', size: 'extraSmall'}),
-      root.createComponent(Text, {appearance: 'subdued'}, 'Checkout'),
+      root.createComponent(
+        InlineStack,
+        {
+          spacing: "extraTight",
+          blockAlignment: "center",
+          accessibilityRole: "listItem",
+        },
+        [
+          root.createComponent(
+            Link,
+            {to: new URL("/collections", storefrontUrl).href},
+            "Shop",
+          ),
+          root.createComponent(Icon, {
+            source: "chevronRight",
+            size: "extraSmall",
+          }),
+        ],
+      ),
+      root.createComponent(
+        InlineStack,
+        {
+          spacing: "extraTight",
+          blockAlignment: "center",
+          accessibilityRole: "listItem",
+        },
+        root.createComponent(Text, { appearance: "subdued" }, "Checkout"),
+      ),
     ],
   );
 
@@ -34,34 +70,56 @@ export default function renderExtension({root, shop}) {
   const rightColumn = root.createComponent(
     InlineStack,
     {
-      spacing: 'tight',
-      inlineAlignment: 'end',
+      blockAlignment: "center",
+      spacing: "tight",
+      inlineAlignment: "end",
+      accessibilityRole: "orderedList",
     },
     [
       root.createComponent(
-        Link,
-        {to: new URL('/sizing', storefrontUrl).href},
-        'Sizing',
+        ListItem,
+        undefined,
+        root.createComponent(
+          Link,
+          {to: new URL("/sizing", storefrontUrl).href},
+          "Sizing",
+        ),
       ),
       root.createComponent(
-        Link,
-        {to: new URL('/terms', storefrontUrl).href},
-        'Terms',
+        ListItem,
+        undefined,
+        root.createComponent(
+          Link,
+          {to: new URL("/terms", storefrontUrl).href},
+          "Terms",
+        ),
       ),
       root.createComponent(
-        Link,
-        {to: new URL('/privacy', storefrontUrl).href},
-        'Privacy',
+        ListItem,
+        undefined,
+        root.createComponent(
+          Link,
+          {to: new URL("/privacy", storefrontUrl).href},
+          "Privacy",
+        ),
       ),
       root.createComponent(
-        Link,
-        {to: new URL('/faq', storefrontUrl).href},
-        'FAQ',
+        ListItem,
+        undefined,
+        root.createComponent(
+          Link,
+          {to: new URL("/faq", storefrontUrl).href},
+          "FAQ",
+        ),
       ),
       root.createComponent(
-        Link,
-        {to: new URL('/accessibility', storefrontUrl).href},
-        'Accessibility',
+        ListItem,
+        undefined,
+        root.createComponent(
+          Link,
+          {to: new URL("/accessibility", storefrontUrl).href},
+          "Accessibility",
+        ),
       ),
     ],
   );

--- a/extensions/custom-footer/src/Extension.js
+++ b/extensions/custom-footer/src/Extension.js
@@ -3,8 +3,8 @@ import {
   InlineLayout,
   InlineStack,
   Link,
-  ListItem,
   Text,
+  View,
 } from '@shopify/ui-extensions/checkout';
 
 // [START custom-footer.render]
@@ -77,8 +77,8 @@ export default function renderExtension({root, shop}) {
     },
     [
       root.createComponent(
-        ListItem,
-        undefined,
+        View,
+        {accessibilityRole: 'listItem'},
         root.createComponent(
           Link,
           {to: new URL("/sizing", storefrontUrl).href},
@@ -86,8 +86,8 @@ export default function renderExtension({root, shop}) {
         ),
       ),
       root.createComponent(
-        ListItem,
-        undefined,
+        View,
+        {accessibilityRole: 'listItem'},
         root.createComponent(
           Link,
           {to: new URL("/terms", storefrontUrl).href},
@@ -95,8 +95,8 @@ export default function renderExtension({root, shop}) {
         ),
       ),
       root.createComponent(
-        ListItem,
-        undefined,
+        View,
+        {accessibilityRole: 'listItem'},
         root.createComponent(
           Link,
           {to: new URL("/privacy", storefrontUrl).href},
@@ -104,8 +104,8 @@ export default function renderExtension({root, shop}) {
         ),
       ),
       root.createComponent(
-        ListItem,
-        undefined,
+        View,
+        {accessibilityRole: 'listItem'},
         root.createComponent(
           Link,
           {to: new URL("/faq", storefrontUrl).href},
@@ -113,8 +113,8 @@ export default function renderExtension({root, shop}) {
         ),
       ),
       root.createComponent(
-        ListItem,
-        undefined,
+        View,
+        {accessibilityRole: 'listItem'},
         root.createComponent(
           Link,
           {to: new URL("/accessibility", storefrontUrl).href},


### PR DESCRIPTION
companion to https://github.com/Shopify/example-checkout--custom-footer--react/pull/3 
To make the example more accessible, adding the `accessibilityRole` to `InlineStack` to render as lists